### PR TITLE
Use full URLs for third-party resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,8 +46,8 @@
                 border: 3px solid black; 
             }
         </style>
-        <!-- <script src="//zeptojs.com/zepto.js"></script> -->
-        <script src="//code.jquery.com/jquery-1.10.1.js"></script>
+        <!-- <script src="http://zeptojs.com/zepto.js"></script> -->
+        <script src="http://code.jquery.com/jquery-1.10.1.js"></script>
         <script src="src/magnifik.js"></script>
 
     </head>
@@ -55,8 +55,8 @@
 
         <div class="magnifik-example basic">
             <h2>Basic magnifik</h2>
-            <a class="z1" href="//www.fillmurray.com/g/601/901">
-                <img src="//www.fillmurray.com/g/601/901">
+            <a class="z1" href="http://www.fillmurray.com/g/601/901">
+                <img src="http://www.fillmurray.com/g/601/901">
             </a>
             <script>$('a.z1').magnifik();</script>
         </div>


### PR DESCRIPTION
We should use full URLs that way we can load the index.html as a file:// locally, ala:
`file://localhost/ude/mi/repos/magnifik/index.html`