### PR TITLE
Feature canvas scroll positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,11 @@ These are the default styles applied to magnified image(s) and their container.
 The `canvasScrollPosition` configuration object has the following structure:
 
     {
-        horizontal: 'center', // Possible values: left | center | right
-        vertical: 'center', // Possible values: top | center | bottom
+        horizontal: 'default', // Possible values: default | left | right
+        vertical: 'default', // Possible values: default | top | bottom
     }
+
+The `default` option zooms to where the user tapped on the thumbnail.
 
 ## Events
 

--- a/README.md
+++ b/README.md
@@ -73,10 +73,11 @@ Below are the options available in the configuration object:
 | seekImage     | `true`         | If thumbnail image is not found in the anchor element used as context, Magnifik will go up in DOM tree until it finds nearby image. Set to `false` to restrict image lookups to stay within context |
 | clickCloses   | `true`         | Specifies if clicking or tapping in place on the magnified image should close magnified view |
 | activationEvent | `"click"` | Override to use alternate event for all magnifik control interactions |
-| canvasStyle  | Object, see below | Extra CSS properties to be applied to canvas. You can delete default properties by setting their value to `undefined`. | 
+| canvasStyle  | Object, see below | Extra CSS properties to be applied to canvas. You can delete default properties by setting their value to `undefined`. |
 | imageStyle   | Object, see below | Extra CSS properties to be applied to low-res and high-res magnified image. You can delete default properties by setting their value to `undefined`. |
 | stageHTML | Function | Generates HTML of magnified state of magnifik module. See examples to see how to change it |
 | globalStyle | Function | Generates CSS for magnifik acting upon <body>. Typically should be left as-is. |
+| canvasScrollPosition | Object, see below | Defines the scroll position for the canvas when zoomed in. |
 
 ## Classes
 
@@ -94,7 +95,7 @@ Below are the options available in the configuration object:
 These are the default styles applied to magnified image(s) and their container.
 
 ### canvasStyle
-    { 
+    {
         position: 'absolute'
       , width: '100%'
       , height: '100%'
@@ -102,12 +103,21 @@ These are the default styles applied to magnified image(s) and their container.
     }
 
 ### imageStyle
-    { 
+    {
         position: 'absolute'
       , top: '0'
       , left: '0'
       , maxWidth: 'none'
       , maxHeight: 'none'        
+    }
+
+## Canvas scroll position
+
+The `canvasScrollPosition` configuration object has the following structure:
+
+    {
+        horizontal: 'center', // Possible values: left | center | right
+        vertical: 'center', // Possible values: top | center | bottom
     }
 
 ## Events
@@ -125,18 +135,18 @@ The magnifik emits the following events:
 
 ## Limitations
 
-Magnifik relies on click event for activation and deactivation. This results 
-in about ~300ms delay in iOS, as Mobile Safari waits to ensure that event 
-in question is a single tap rather than built-in page zooming double tap. 
-We do not bundle a quick tap implementation with magnifik, but you can 
-attach a tap event manually. Here is an example of custom binding that 
+Magnifik relies on click event for activation and deactivation. This results
+in about ~300ms delay in iOS, as Mobile Safari waits to ensure that event
+in question is a single tap rather than built-in page zooming double tap.
+We do not bundle a quick tap implementation with magnifik, but you can
+attach a tap event manually. Here is an example of custom binding that
 uses [jQuery tappable](https://github.com/aanand/jquery.tappable.js/blob/master/jquery.tappable.js):
 
     var el = $('a.magnifik').magnifik();
     el.tappable(function() {
         $(this).magnifik('show');
     });
-    
+
 Other quick touch implementations can be used in similar ways.
 
 -->

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "magnifik",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "homepage": "https://github.com/mobify/magnifik",
   "authors": [
     "Mobify <jobs@mobify.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobify-magnifik",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "An image zooming module for mobile",
   "devDependencies": {
     "grunt": "~0.4.x",

--- a/src/magnifik.js
+++ b/src/magnifik.js
@@ -73,6 +73,11 @@ Mobify.UI.Magnifik = (function() {
                   + zooming + ' > * { display: none !important; }'
                   + zooming + ' > .' + this._getClass('control') + ' { display: block !important; }';
             }
+            // Default canvas scroll position. Overriding replaces the whole object.
+            , canvasScrollPosition: {
+                horizontal: 'center', // left | center | right
+                vertical: 'center', // top | center | bottom
+            }
         }
 
         // stage: where the thing is inserted
@@ -211,10 +216,25 @@ Mobify.UI.Magnifik = (function() {
           , bigHeight = thumbWidth * imgAspect
           , thus = this;
 
-        thus.$canvas.prop('scrollLeft', Math.max(0, Math.min(bigWidth - smallWidth,
-            bigWidth * leftRatio - smallWidth / 2)));
-        thus.$canvas.prop('scrollTop', Math.max(0, Math.min(bigHeight - smallHeight,
-            bigHeight * topRatio - smallHeight / 2)));
+        // Set the desired "scrollLeft" position
+        if (this.options.canvasScrollPosition.horizontal === 'left') {
+            thus.$canvas.prop('scrollLeft', 0);
+        } else if (this.options.canvasScrollPosition.horizontal === 'center') {
+            thus.$canvas.prop('scrollLeft', Math.max(0, Math.min(bigWidth - smallWidth,
+                bigWidth * leftRatio - smallWidth / 2)));
+        } else if (this.options.canvasScrollPosition.horizontal === 'right') {
+            thus.$canvas.prop('scrollLeft', bigWidth);
+        }
+
+        // Set the desired "scrollTop" position
+        if (this.options.canvasScrollPosition.vertical === 'top') {
+            thus.$canvas.prop('scrollTop', 0);
+        } else if (this.options.canvasScrollPosition.vertical === 'center') {
+            thus.$canvas.prop('scrollTop', Math.max(0, Math.min(bigHeight - smallHeight,
+                bigHeight * topRatio - smallHeight / 2)));
+        } else if (this.options.canvasScrollPosition.vertical === 'bottom') {
+            thus.$canvas.prop('scrollTop', bigHeight);
+        }
 
         thus.$element.trigger('magnifik:open');
     };

--- a/src/magnifik.js
+++ b/src/magnifik.js
@@ -75,8 +75,8 @@ Mobify.UI.Magnifik = (function() {
             }
             // Default canvas scroll position. Overriding replaces the whole object.
             , canvasScrollPosition: {
-                horizontal: 'center', // left | center | right
-                vertical: 'center', // top | center | bottom
+                horizontal: 'default', // default | left | right
+                vertical: 'default', // default | top | bottom
             }
         }
 
@@ -219,21 +219,21 @@ Mobify.UI.Magnifik = (function() {
         // Set the desired "scrollLeft" position
         if (this.options.canvasScrollPosition.horizontal === 'left') {
             thus.$canvas.prop('scrollLeft', 0);
-        } else if (this.options.canvasScrollPosition.horizontal === 'center') {
-            thus.$canvas.prop('scrollLeft', Math.max(0, Math.min(bigWidth - smallWidth,
-                bigWidth * leftRatio - smallWidth / 2)));
         } else if (this.options.canvasScrollPosition.horizontal === 'right') {
             thus.$canvas.prop('scrollLeft', bigWidth);
+        } else if (this.options.canvasScrollPosition.horizontal === 'default') {
+            thus.$canvas.prop('scrollLeft', Math.max(0, Math.min(bigWidth - smallWidth,
+                bigWidth * leftRatio - smallWidth / 2)));
         }
 
         // Set the desired "scrollTop" position
         if (this.options.canvasScrollPosition.vertical === 'top') {
             thus.$canvas.prop('scrollTop', 0);
-        } else if (this.options.canvasScrollPosition.vertical === 'center') {
-            thus.$canvas.prop('scrollTop', Math.max(0, Math.min(bigHeight - smallHeight,
-                bigHeight * topRatio - smallHeight / 2)));
         } else if (this.options.canvasScrollPosition.vertical === 'bottom') {
             thus.$canvas.prop('scrollTop', bigHeight);
+        } else if (this.options.canvasScrollPosition.vertical === 'default') {
+            thus.$canvas.prop('scrollTop', Math.max(0, Math.min(bigHeight - smallHeight,
+                bigHeight * topRatio - smallHeight / 2)));
         }
 
         thus.$element.trigger('magnifik:open');


### PR DESCRIPTION
Adds the ability to set a default scroll position when an image is zoomed in.

Status: **Ready for review**

Reviewers: @marlowpayne @jnurse @donnielrt 
## Changes
- Added a new `canvasScrollPosition` options object
- Specified default values for the above
- Updated README.md
- Bumped minor version
## Notes
- The default behaviour is kept by setting both scroll directions to _center_
